### PR TITLE
Added NEW_RELIC_APP_NAME env var for app.json

### DIFF
--- a/{{cookiecutter.repo_name}}/app.json
+++ b/{{cookiecutter.repo_name}}/app.json
@@ -22,6 +22,7 @@
     "DJANGO_MAILGUN_SERVER_NAME": "",
     {% if cookiecutter.use_newrelic == "y" -%}
     "NEW_RELIC_LICENSE_KEY": "",
+    "NEW_RELIC_APP_NAME": "",
     {%- endif %}
     "DJANGO_MAILGUN_API_KEY": ""{% if cookiecutter.use_sentry == "y" -%},
     "DJANGO_SENTRY_DSN": ""{%- endif %} 


### PR DESCRIPTION
When using the one-click deployment to Heroku the building process fails if the app uses NewRelic.
